### PR TITLE
Improve tags sorting

### DIFF
--- a/versiontag
+++ b/versiontag
@@ -129,7 +129,7 @@ function showCurrentVersion() {
 # Get the last tag and breaks into parts
 
 function getLastTag() {
-    lasttag=`git tag | sort -r | grep "^v[0-9]*\.[0-9]*\.[0-9]" | head -1 2> /dev/null` || true
+    lasttag=`git tag -l --sort=-committerdate | grep "^v[0-9]*\.[0-9]*\.[0-9]" | head -1 2> /dev/null` || true
 
     if [[ -z "$lasttag" ]]; then
         lasttag='v0.0.0'

--- a/versiontag
+++ b/versiontag
@@ -129,7 +129,7 @@ function showCurrentVersion() {
 # Get the last tag and breaks into parts
 
 function getLastTag() {
-    lasttag=`git tag -l --sort=-committerdate | grep "^v[0-9]*\.[0-9]*\.[0-9]" | head -1 2> /dev/null` || true
+    lasttag=`git tag -l --sort=-committerdate | head -1 2> /dev/null` || true
 
     if [[ -z "$lasttag" ]]; then
         lasttag='v0.0.0'


### PR DESCRIPTION
- use sorting option of `git` command, it allows to sort tags by date. `sort -r` doesn't work properly in all cases, e.g. if there are two tags exist `0.3.9` and `0.3.68`, then `sort -r` will return `0.3.9` as first tag
- `grep "^v[0-9]*\.[0-9]*\.[0-9]"` doesn't make sense here, `git tag -l --sort=-committerdate` returns only the list of tags